### PR TITLE
Corepack Support & Dependabot Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   "dependencies": {
     "@astrojs/vercel": "^7.6.0",
     "astro": "^4.8.4"
-  }
+  },
+  "packageManager": "pnpm@9.4.0"
 }


### PR DESCRIPTION
This PR adds `packageManager` field to the `package.json` file of the repo in order to support Corepack. This also fixes the issue with Dependabot version upgrades resetting the pnpm lockfile to v6.